### PR TITLE
Digital write fast bitband

### DIFF
--- a/arduino/opencm_arduino/opencm9.04/cores/arduino/Arduino.h
+++ b/arduino/opencm_arduino/opencm9.04/cores/arduino/Arduino.h
@@ -97,5 +97,6 @@ void noTone(uint8_t _pin);
 #include "wiring_analog.h"
 #include "wiring_shift.h"
 #include "WInterrupts.h"
+#include "digitalWriteFast.h"
 
 #endif // Arduino_h

--- a/arduino/opencm_arduino/opencm9.04/cores/arduino/digitalWriteFast.h
+++ b/arduino/opencm_arduino/opencm9.04/cores/arduino/digitalWriteFast.h
@@ -1,0 +1,69 @@
+/*
+  digitalWriteFast.h - A faster digitalWrite and digitalRead
+  ...based partially on digitalWrite fast code by Paul Stoffregen,
+  as part of Teensyduino and partially based off of the earlier
+  arduino version http://code.google.com/p/digitalwritefast
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with this library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+/* Only want to process this if pin count has been defined which inplies that the full variant.h has been read */
+
+#ifdef PINS_COUNT 
+#ifndef _DIGITAL_WRITE_FAST_
+#define _DIGITAL_WRITE_FAST_
+
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+static inline void digitalWriteFast(uint8_t, uint8_t) __attribute__((always_inline, unused));
+static inline void digitalWriteFast(uint8_t pin, uint8_t val)
+{
+  if (__builtin_constant_p(pin)) {
+    if (val) {
+      if(pin < PINS_COUNT - 1) {
+        g_Pin2PortMapArray[pin].GPIOx_Port->BSRR = g_Pin2PortMapArray[pin].Pin_abstraction;
+      }
+    } else {
+      if (pin < PINS_COUNT - 1) {
+        g_Pin2PortMapArray[pin].GPIOx_Port->BSRR = (g_Pin2PortMapArray[pin].Pin_abstraction << 16);
+      }
+    }
+  } else {
+    digitalWrite(pin, val);
+  }
+}
+
+
+static inline int digitalReadFast(uint8_t) __attribute__((always_inline, unused));
+static inline int digitalReadFast(uint8_t pin)
+{
+  if (__builtin_constant_p(pin)) {
+    if (pin < PINS_COUNT - 1) {
+      return (g_Pin2PortMapArray[pin].GPIOx_Port->IDR & g_Pin2PortMapArray[pin].Pin_abstraction)? HIGH : LOW;
+    }
+  } 
+  return digitalRead(pin);
+}
+
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
+
+
+#endif /* _DIGITAL_WRITE_FAST_ */
+#endif /* PINS_COUNT */

--- a/arduino/opencm_arduino/opencm9.04/libraries/OpenCM9.04/examples/01_Basics/g_Gpio_Write_Speed_Test/g_Gpio_Write_Speed_Test.ino
+++ b/arduino/opencm_arduino/opencm9.04/libraries/OpenCM9.04/examples/01_Basics/g_Gpio_Write_Speed_Test/g_Gpio_Write_Speed_Test.ino
@@ -1,0 +1,51 @@
+/* Author: KurtE
+ * Modified by : Kei
+ */
+
+GPIO_TypeDef *pin0_port;
+uint32_t  pin0_set_mask;
+uint32_t  pin0_clear_mask;
+
+void setup() {
+  while(!Serial && millis() < 5000) ; 
+  Serial.begin(115200);
+  
+  pinMode (0, OUTPUT);
+  
+  // For register access directly
+  pin0_port = g_Pin2PortMapArray[0].GPIOx_Port;
+  pin0_set_mask = g_Pin2PortMapArray[0].Pin_abstraction;
+  pin0_clear_mask = (uint32_t)g_Pin2PortMapArray[0].Pin_abstraction << 16;
+}
+
+void loop() {
+  // Write Method1 : digitalWrite
+  uint32_t start_time = micros();
+  digitalWrite(0, HIGH);
+  digitalWrite(0, LOW);
+  digitalWrite(0, HIGH);
+  digitalWrite(0, LOW);
+  digitalWrite(0, HIGH);
+  digitalWrite(0, LOW);
+  uint32_t dw_time = micros();
+
+  // Write Method2 : Access register directly
+  pin0_port->BSRR = pin0_set_mask;
+  pin0_port->BSRR = pin0_clear_mask;
+  pin0_port->BSRR = pin0_set_mask;
+  pin0_port->BSRR = pin0_clear_mask;
+  pin0_port->BSRR = pin0_set_mask;
+  pin0_port->BSRR = pin0_clear_mask;
+  uint32_t reg_time = micros();
+  
+  // Write Method3 : digitalWriteFast
+  digitalWriteFast(0, HIGH);
+  digitalWriteFast(0, LOW);
+  digitalWriteFast(0, HIGH);
+  digitalWriteFast(0, LOW);
+  digitalWriteFast(0, HIGH);
+  digitalWriteFast(0, LOW);
+  uint32_t dwf_time = micros();
+  Serial.printf("digitalWrite:%d Regs:%d digitalWriteFast:%d\n", dw_time-start_time, reg_time-dw_time, dwf_time-reg_time);
+  delay(500);
+}

--- a/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/variant.cpp
+++ b/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/variant.cpp
@@ -72,6 +72,41 @@ extern const Pin2PortMapArray g_Pin2PortMapArray[]=
     {NULL , 0          ,  NULL,     NO_ADC        , NULL   ,   NO_PWM       , NO_EXTI }
 };
 
+const uint32_t *digital_pin_bitband_table[]
+{
+    GPIO_BITBAND_PTR(GPIOA->ODR, 4),  // 0
+    GPIO_BITBAND_PTR(GPIOA->ODR, 5),  // 1                  SPI1_SCK
+    GPIO_BITBAND_PTR(GPIOA->ODR, 0),  // 2
+    GPIO_BITBAND_PTR(GPIOA->ODR, 1),  // 3
+    GPIO_BITBAND_PTR(GPIOA->ODR, 2),  // 4                              UART1_TXD
+    GPIO_BITBAND_PTR(GPIOA->ODR, 3),  // 5                              UART1_RXD
+    GPIO_BITBAND_PTR(GPIOA->ODR, 6),  // 6                  SPI1_MISO
+    GPIO_BITBAND_PTR(GPIOA->ODR, 7),  // 7                  SPI1_MOSI
+    GPIO_BITBAND_PTR(GPIOB->ODR, 0),  // 8
+    GPIO_BITBAND_PTR(GPIOB->ODR, 1),  // 9
+    GPIO_BITBAND_PTR(GPIOA->ODR, 8),  // 10
+    GPIO_BITBAND_PTR(GPIOA->ODR, 9),  // 11                             UART2_TXD
+    GPIO_BITBAND_PTR(GPIOA->ODR, 10),  // 12                             UART2_RXD
+    GPIO_BITBAND_PTR(GPIOB->ODR, 8),  // 13                 I2C1 SCL
+    GPIO_BITBAND_PTR(GPIOB->ODR, 9),  // 14 LED             I2C1 SDA
+    GPIO_BITBAND_PTR(GPIOA->ODR, 15),  // 15
+    GPIO_BITBAND_PTR(GPIOB->ODR, 3),  // 16
+    GPIO_BITBAND_PTR(GPIOB->ODR, 4),  // 17
+    GPIO_BITBAND_PTR(GPIOB->ODR, 12),  // 18
+    GPIO_BITBAND_PTR(GPIOB->ODR, 13),  // 19                 SPI2_SCK
+    GPIO_BITBAND_PTR(GPIOB->ODR, 14),  // 20                 SPI2_MISO
+    GPIO_BITBAND_PTR(GPIOB->ODR, 15),  // 21                 SPI2_MOSI
+    GPIO_BITBAND_PTR(GPIOC->ODR, 14),  // 22
+    GPIO_BITBAND_PTR(GPIOC->ODR, 15),  // 23 USER_BUTTON
+    GPIO_BITBAND_PTR(GPIOB->ODR, 10),  // 24                 I2C2 SCL    UART3_TXD
+    GPIO_BITBAND_PTR(GPIOB->ODR, 11),  // 25                 I2C2 SCL    UART3_RXD
+    GPIO_BITBAND_PTR(GPIOA->ODR, 13),  // 26 JTAG SWDIO
+    GPIO_BITBAND_PTR(GPIOA->ODR, 14),  // 27 JTAG SWDCLK
+    GPIO_BITBAND_PTR(GPIOB->ODR, 5),  // 28 DXL DIR
+    GPIO_BITBAND_PTR(GPIOB->ODR, 6),  // 29 DXL TXD
+    GPIO_BITBAND_PTR(GPIOB->ODR, 7)  // 30 DXL RXD
+};
+
 
 #ifdef __cplusplus
 }

--- a/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/variant.h
+++ b/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/variant.h
@@ -88,6 +88,23 @@ typedef struct _Pin2PortMapArray
 
 extern const Pin2PortMapArray g_Pin2PortMapArray[];
 
+// Arm M3 standard bit band definitions. 
+#define GPIO_BITBAND_ADDR(reg, bit) (((uint32_t)&(reg) - 0x40000000) * 32 + (bit) * 4 + 0x42000000)
+#define GPIO_BITBAND_PTR(reg, bit) ((uint32_t *)GPIO_BITBAND_ADDR((reg), (bit)))
+
+extern const uint32_t *digital_pin_bitband_table[];
+// compatibility macros
+#define digitalPinToPort(pin) (pin)
+#define digitalPinToBitMask(pin) (1)
+#define portOutputRegister(pin) ((volatile uint32_t *)(digital_pin_bitband_table[(pin)] + 0))    // We point to ODR so 0 offset
+#define portInputRegister(pin)  ((volatile uint32_t *)(digital_pin_bitband_table[(pin)] - 32))  // ODR offset(0xc) IDR Offset(0x8) so offset -4*32
+
+#define portSetRegister(pin)    ((volatile uint32_t *)(digital_pin_bitband_table[(pin)] + 32))  // BSRR(0x10) so offset +4*32
+#define portClearRegister(pin)  ((volatile uint32_t *)(digital_pin_bitband_table[(pin)] + 64))  // brr(0X14) so offset +8*32 or could also use BSRR
+#define digitalPinToPortReg(pin) (portOutputRegister(pin))
+#define digitalPinToBit(pin) (1)
+
+
 void Rx1_Handler(void);
 void Tx1_Handler(void);
 void Rx2_Handler(void);
@@ -126,6 +143,7 @@ extern UARTClass Serial3;   // Serial for UART3
 
 #define digitalPinToInterrupt(P)   ( g_Pin2PortMapArray[P].extiChannel )
 #define analogPinToChannel(p)      ( (p) < 10 ? (p)+A0 : (p) )
+
 
 void  var_init();
 void  toggleLED(void);


### PR DESCRIPTION
I copied over the digitalWriteFast code that we added to OpenCR and added it here, including the sample app. 

Also in addition, I added some support for some of the some of the Arduino pin mapping macros, like:
```
// Arm M3 standard bit band definitions. 
#define GPIO_BITBAND_ADDR(reg, bit) (((uint32_t)&(reg) - 0x40000000) * 32 + (bit) * 4 + 0x42000000)
#define GPIO_BITBAND_PTR(reg, bit) ((uint32_t *)GPIO_BITBAND_ADDR((reg), (bit)))

extern const uint32_t *digital_pin_bitband_table[];
// compatibility macros
#define digitalPinToPort(pin) (pin)
#define digitalPinToBitMask(pin) (1)
#define portOutputRegister(pin) ((volatile uint32_t *)(digital_pin_bitband_table[(pin)] + 0))    // We point to ODR so 0 offset
#define portInputRegister(pin)  ((volatile uint32_t *)(digital_pin_bitband_table[(pin)] - 32))  // ODR offset(0xc) IDR Offset(0x8) so offset -4*32

#define portSetRegister(pin)    ((volatile uint32_t *)(digital_pin_bitband_table[(pin)] + 32))  // BSRR(0x10) so offset +4*32
#define portClearRegister(pin)  ((volatile uint32_t *)(digital_pin_bitband_table[(pin)] + 64))  // brr(0X14) so offset +8*32 or could also use BSRR
#define digitalPinToPortReg(pin) (portOutputRegister(pin))
#define digitalPinToBit(pin) (1)
```
This was defined using Bitband support.   Probably more testing needs to be done.  I have not yet tried the portInputRegister to see if that works.  

Some of the other platforms have additional macros, like to change pin mode and the like, which may still need to be done. 

Test program:
```
int led_pin = 14;
#define GPIO_BITBAND_ADDR(reg, bit) (((uint32_t)&(reg) - 0x40000000) * 32 + (bit) * 4 + 0x42000000)
#define GPIO_BITBAND_PTR(reg, bit) ((uint32_t *)GPIO_BITBAND_ADDR((reg), (bit)))

volatile uint32_t *led_output_register;
volatile uint32_t *led_input_register;
volatile uint32_t *led_set_register;
volatile uint32_t *led_clear_register;
uint32_t led_mask;

void setup() {
  // Set up the built-in LED pin as an output:
  pinMode(led_pin, OUTPUT);

  while (!Serial && millis() < 4000) ;
  Serial.begin(115200);

  led_output_register = portOutputRegister(digitalPinToPort(led_pin));
  led_input_register = portInputRegister(digitalPinToPort(led_pin));
  led_set_register =  portSetRegister(digitalPinToPort(led_pin));
  led_clear_register = portClearRegister(digitalPinToPort(led_pin));;
  led_mask = digitalPinToBitMask(led_pin);

  // Test digitalWriteFast
  for (int i = 0; i < 10; i++) {
    digitalWriteFast(led_pin, HIGH);
    delay(100);
    digitalWriteFast(led_pin, LOW);
    delay(100);
  }
}

void loop() {
  // Do first with output register. 
//  Serial.println("*led_output_register |= led_mask - Press Enter to continue"); while(Serial.read() == -1) ; while (Serial.read() != -1) ; 
  *led_output_register |= led_mask;      // digitalWrite(HIGH);
  delay(500);
//  Serial.println("*led_output_register &= ~led_mask - Press Enter to continue"); while(Serial.read() == -1) ; while (Serial.read() != -1) ; 
  *led_output_register &= ~led_mask;        // digitalWrite(LOW);
  delay(500);
//  Serial.println("*led_set_register = led_mask - Press Enter to continue"); while(Serial.read() == -1) ; while (Serial.read() != -1) ; 
  *led_set_register = led_mask;
  delay(100);
//  Serial.println("*led_clear_register = led_mask - Press Enter to continue"); while(Serial.read() == -1) ; while (Serial.read() != -1) ; 
  *led_clear_register = led_mask;
  delay(100);
}
```

Side note:  I again rigged up the ability to build using the develop branch in similar way did for OpenCR board.  Where I create a folder under <sketch folders>/hardware/opencm904
Name of folder is important including case.  In here created a directory symlink to the develop branch...

I also edited board.txt to add (develop) as part of board name, so could know which of the two I am using. 

Build issue: Will fail in the link phase, looking for the prebuilt library  (lib_f103.a), so edited platform.txt to remove the include of this as building full sources....

But I get a command line warning after every compile line, that looks like:
```
"C:\Users\kurte\AppData\Local\Arduino15\packages\OpenCM904\tools\opencm_gcc\5.4.0-2016q2/bin/arm-none-eabi-g++" -c -g -O2 -std=gnu++11 -Wno-write-strings  -MMD -ffunction-sections -fdata-sections  -fno-rtti -fno-exceptions -DARM_MATH_CM3 -DUSE_HAL_DRIVER -DBOARD_OpenCM904 -mcpu=cortex-m3 -DF_CPU=72000000L -DARDUINO=10805 -DARDUINO_OpenCM904 -DARDUINO_ARCH_OPENCM9.04     -mthumb  -DSTM32F103xB -D__OPENCM904__ "-IC:\Users\kurte\Documents\Arduino\hardware\opencm904\opencm9.04\variants\OpenCM904/bsp/opencm" "-IC:\Users\kurte\Documents\Arduino\hardware\opencm904\opencm9.04\variants\OpenCM904/bsp/opencm/include" "-IC:\Users\kurte\Documents\Arduino\hardware\opencm904\opencm9.04\variants\OpenCM904/hw" "-IC:\Users\kurte\Documents\Arduino\hardware\opencm904\opencm9.04\variants\OpenCM904/hw/driver" "-IC:\Users\kurte\Documents\Arduino\hardware\opencm904\opencm9.04\variants\OpenCM904/hw/usb_cdc" "-IC:\Users\kurte\Documents\Arduino\hardware\opencm904\opencm9.04\variants\OpenCM904/lib/STM32F1xx_HAL_Driver/Inc/" "-IC:\Users\kurte\Documents\Arduino\hardware\opencm904\opencm9.04\variants\OpenCM904/" "-IC:\Users\kurte\Documents\Arduino\hardware\opencm904\opencm9.04\cores\arduino" "-IC:\Users\kurte\Documents\Arduino\hardware\opencm904\opencm9.04\variants\OpenCM904" "C:\Users\kurte\AppData\Local\Temp\arduino_build_98387\sketch\blink_led_bitband.ino.cpp" -o "C:\Users\kurte\AppData\Local\Temp\arduino_build_98387\sketch\blink_led_bitband.ino.cpp.o"
<command-line>:0:21: warning: ISO C++11 requires whitespace after the macro name
```
Not sure if this is because of my setup or not? 