### PR TITLE
Serial flush faster

### DIFF
--- a/arduino/opencm_arduino/opencm9.04/cores/arduino/USBSerial.cpp
+++ b/arduino/opencm_arduino/opencm9.04/cores/arduino/USBSerial.cpp
@@ -77,8 +77,9 @@ int USBSerial::read(void)
   return vcp_getch();
 }
 
-void USBSerial::flush(void){
-  while(vcp_is_transmitted() == FALSE);
+void USBSerial::flush(void)
+{
+  vcp_flush_tx();
 }
 
 size_t USBSerial::write(const uint8_t *buffer, size_t size)

--- a/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/hw/driver/swtimer.c
+++ b/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/hw/driver/swtimer.c
@@ -109,6 +109,14 @@ void swtimerSet(uint8_t TmrNum, uint32_t TmrData, uint8_t TmrMode, void (*Fnct)(
   swtimer_tbl[TmrNum].Timer_Init = TmrData;
 }
 
+void swTimerSetCnt (uint8_t TmrNum, uint32_t TmrCnt) 
+{
+  if(TmrNum < _HW_DEF_SW_TIMER_MAX)
+  {
+    swtimer_tbl[TmrNum].Timer_Ctn = TmrCnt; 
+  }
+}
+
 void swtimerStart(uint8_t TmrNum)
 {
   if(TmrNum < _HW_DEF_SW_TIMER_MAX)

--- a/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/hw/driver/swtimer.h
+++ b/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/hw/driver/swtimer.h
@@ -57,6 +57,7 @@ typedef struct
 
 bool swtimerInit(void);
 void swtimerSet  (uint8_t TmrNum, uint32_t TmrData, uint8_t TmrMode, void (*Fnct)(void *),void *arg);
+void swTimerSetCnt (uint8_t TmrNum, uint32_t TmrCnt);
 void swtimerStart(uint8_t TmrNum);
 void swtimerStop (uint8_t TmrNum);
 void swtimerReset(uint8_t TmrNum);

--- a/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/hw/driver/vcp.c
+++ b/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/hw/driver/vcp.c
@@ -106,9 +106,9 @@ void vcp_detach_rx_interrupt(void)
 
 }
 
-BOOL vcp_is_transmitted( void )
+void vcp_flush_tx( void ) 
 {
-  return CDC_Itf_IsTxTransmitted();
+  CDC_Itf_flush_tx();
 }
 
 int32_t vcp_printf( const char *fmt, ...)

--- a/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/hw/driver/vcp.h
+++ b/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/hw/driver/vcp.h
@@ -27,7 +27,7 @@ BOOL     vcp_is_connected(void);
 void     vcp_putch(uint8_t ch);
 uint8_t  vcp_getch(void);
 int32_t  vcp_write(uint8_t *p_data, uint32_t length);
-BOOL     vcp_is_transmitted(void);
+void 	 vcp_flush_tx(void);
 
 int32_t  vcp_printf( const char *fmt, ...);
 

--- a/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/hw/usb_cdc/usbd_cdc_interface.h
+++ b/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/hw/usb_cdc/usbd_cdc_interface.h
@@ -74,7 +74,8 @@ uint8_t  CDC_Itf_Getch( void );
 uint8_t  CDC_Itf_Read( void );
 bool     CDC_Itf_IsConnected(void);
 int32_t  CDC_Itf_Peek( void );
-BOOL     CDC_Itf_IsTxTransmitted( void );
+void     CDC_Itf_flush_tx ( void );
+
 
 /* Exported macro ------------------------------------------------------------*/
 /* Exported functions ------------------------------------------------------- */

--- a/arduino/opencm_arduino/opencm9.04_release/variants/OpenCM904/hw/driver/swtimer.h
+++ b/arduino/opencm_arduino/opencm9.04_release/variants/OpenCM904/hw/driver/swtimer.h
@@ -57,6 +57,7 @@ typedef struct
 
 bool swtimerInit(void);
 void swtimerSet  (uint8_t TmrNum, uint32_t TmrData, uint8_t TmrMode, void (*Fnct)(void *),void *arg);
+void swTimerSetCnt (uint8_t TmrNum, uint32_t TmrCnt);
 void swtimerStart(uint8_t TmrNum);
 void swtimerStop (uint8_t TmrNum);
 void swtimerReset(uint8_t TmrNum);

--- a/arduino/opencm_arduino/opencm9.04_release/variants/OpenCM904/hw/driver/vcp.h
+++ b/arduino/opencm_arduino/opencm9.04_release/variants/OpenCM904/hw/driver/vcp.h
@@ -27,7 +27,7 @@ BOOL     vcp_is_connected(void);
 void     vcp_putch(uint8_t ch);
 uint8_t  vcp_getch(void);
 int32_t  vcp_write(uint8_t *p_data, uint32_t length);
-BOOL     vcp_is_transmitted(void);
+void 	 vcp_flush_tx(void);
 
 int32_t  vcp_printf( const char *fmt, ...);
 

--- a/arduino/opencm_arduino/opencm9.04_release/variants/OpenCM904/hw/usb_cdc/usbd_cdc_interface.h
+++ b/arduino/opencm_arduino/opencm9.04_release/variants/OpenCM904/hw/usb_cdc/usbd_cdc_interface.h
@@ -74,7 +74,8 @@ uint8_t  CDC_Itf_Getch( void );
 uint8_t  CDC_Itf_Read( void );
 bool     CDC_Itf_IsConnected(void);
 int32_t  CDC_Itf_Peek( void );
-BOOL     CDC_Itf_IsTxTransmitted( void );
+void     CDC_Itf_flush_tx ( void );
+
 
 /* Exported macro ------------------------------------------------------------*/
 /* Exported functions ------------------------------------------------------- */


### PR DESCRIPTION
Current version that worked, just simply waited for up to 5ms for the timer to write the data out.

In this version, I changed the timer to 3ms which obviously helps some, but in addition added a swTimer function which allows you to set the counter. So in the flush function, I force the count to 1, which will imply that the write function will be called on the next millisecond timer.

I updated the whole path of code for flush, where instead of asking if the writes were done, I created a flush_tx function at each level and all of this work was done in the usbd_cdc_interface function, which file already knows (it created) the timer.

Without the timer update change I have a test case, where I basically ask an AX servo for it's current position, and print it out and then call Serial.flush. I put calls in to micros() around the calls to Serial.write/Serial.flush and sum the delta times and with only the change from 5 to 3ms, the average time for the flush to take was about 2.8ms. With the force to next ms, the average time was about .7ms...

This is an alternative update for issue #33 