### PR TITLE
Compile on RPI3...

### DIFF
--- a/arduino/opencm_arduino/opencm9.04/cores/arduino/itoa.h
+++ b/arduino/opencm_arduino/opencm9.04/cores/arduino/itoa.h
@@ -33,6 +33,10 @@ extern char* itoa( int value, char *string, int radix ) ;
 extern char* ltoa( long value, char *string, int radix ) ;
 //extern char* utoa( unsigned long value, char *string, int radix ) ;
 extern char* ultoa( unsigned long value, char *string, int radix ) ;
+#if defined(_NEWLIB_VERSION) && (__NEWLIB__ < 2 || __NEWLIB__ == 2 && __NEWLIB_MINOR__ < 2)
+static inline char * utoa(unsigned int val, char *buf, int radix) __attribute__((always_inline, unused));
+static inline char * utoa(unsigned int val, char *buf, int radix) { return ultoa(val, buf, radix); }
+#endif
 #endif /* 0 */
 
 #ifdef __cplusplus

--- a/arduino/opencm_arduino/opencm9.04_release/cores/arduino/itoa.h
+++ b/arduino/opencm_arduino/opencm9.04_release/cores/arduino/itoa.h
@@ -33,6 +33,10 @@ extern char* itoa( int value, char *string, int radix ) ;
 extern char* ltoa( long value, char *string, int radix ) ;
 //extern char* utoa( unsigned long value, char *string, int radix ) ;
 extern char* ultoa( unsigned long value, char *string, int radix ) ;
+#if defined(_NEWLIB_VERSION) && (__NEWLIB__ < 2 || __NEWLIB__ == 2 && __NEWLIB_MINOR__ < 2)
+static inline char * utoa(unsigned int val, char *buf, int radix) __attribute__((always_inline, unused));
+static inline char * utoa(unsigned int val, char *buf, int radix) { return ultoa(val, buf, radix); }
+#endif
 #endif /* 0 */
 
 #ifdef __cplusplus


### PR DESCRIPTION
As I found out yesterday trying to build on RPI3 as part of testing upload tool for Linux ARM as part of issue #27 that I could not build the develop branch on the RPI3.  There was an issue that utoa was not defined. 

I found that on a Teensy, this function is defined if we have a newlib version of Less than 2.2 ...