### PR TITLE
EEPROM Changes to 2 byte after 4 byte version merged.

### DIFF
--- a/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/hw/driver/drv_eeprom.c
+++ b/arduino/opencm_arduino/opencm9.04/variants/OpenCM904/hw/driver/drv_eeprom.c
@@ -58,19 +58,33 @@ static const uint16_t VirtAddVarTab[NB_OF_VAR] =
 uint16_t EE_Init(void);
 uint16_t EE_ReadVariable(uint16_t VirtAddress, uint16_t* Data);
 uint16_t EE_WriteVariable(uint16_t VirtAddress, uint16_t Data);
+static uint16_t EE_PageConvert(uint16_t validpage);
 
 
 
+// Lets try defer of EEPROM code until someone needs it
+bool drv_eeprom_is_valid(void)
+{
+  if (!IsInit) 
+  {
+    if( EE_Init() == HAL_OK )
+    {
+      IsInit = true;
+    }    
+  }
+  return IsInit;
+}
 
 
 int drv_eeprom_init()
 {
   HAL_FLASH_Unlock();
-
+#if 0  // we will try to defer the actual init until we need it
   if( EE_Init() == HAL_OK )
   {
     IsInit = true;
   }
+#endif  
   return 0;
 }
 
@@ -81,7 +95,7 @@ uint8_t drv_eeprom_read_byte(int addr)
   uint16_t read_value;
 
 
-  if( IsInit == false ) return 0;
+  if( !drv_eeprom_is_valid()) return 0;
 
   EE_ReadVariable((uint16_t)addr,  &read_value);
 
@@ -91,7 +105,7 @@ uint8_t drv_eeprom_read_byte(int addr)
 
 void drv_eeprom_write_byte(int index, uint8_t data_in)
 {
-  if( IsInit == false ) return;
+  if( !drv_eeprom_is_valid()) return;
 
   EE_WriteVariable(index, (uint16_t)data_in);
 }
@@ -99,7 +113,7 @@ void drv_eeprom_write_byte(int index, uint8_t data_in)
 
 uint16_t drv_eeprom_get_length(void)
 {
-  if( IsInit == false ) return 0;
+  if( !drv_eeprom_is_valid()) return 0;
 
   return NB_OF_VAR;
 }
@@ -137,6 +151,7 @@ uint16_t drv_eeprom_get_length(void)
 #define ERASED                ((uint16_t)0xFFFF)     /* Page is empty */
 #define RECEIVE_DATA          ((uint16_t)0xEEEE)     /* Page is marked to receive data */
 #define VALID_PAGE            ((uint16_t)0x0000)     /* Page containing valid data */
+#define PAGE_VERSION          ((uint16_t)0x0002)     /* Version 2 - Version 1 was 0xffff */
 
 /* Valid pages in read and write defines */
 #define READ_FROM_VALID_PAGE  ((uint8_t)0x00)
@@ -201,6 +216,8 @@ uint16_t EE_Init(void)
             return flashstatus;
           }
         }
+        // Check and maybe convert page format
+        flashstatus = EE_PageConvert(PAGE1);
       }
       else if (pagestatus1 == RECEIVE_DATA) /* Page0 erased, Page1 receive */
       {
@@ -216,6 +233,7 @@ uint16_t EE_Init(void)
         }
         /* Mark Page1 as valid */
         flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, PAGE1_BASE_ADDRESS, VALID_PAGE);
+        flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, PAGE1_BASE_ADDRESS+2, PAGE_VERSION);
         /* If program operation was failed, a Flash error code is returned */
         if (flashstatus != HAL_OK)
         {
@@ -263,6 +281,7 @@ uint16_t EE_Init(void)
         }
         /* Mark Page0 as valid */
         flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, PAGE0_BASE_ADDRESS, VALID_PAGE);
+        flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, PAGE0_BASE_ADDRESS+2, PAGE_VERSION);
         /* If program operation was failed, a Flash error code is returned */
         if (flashstatus != HAL_OK)
         {
@@ -299,6 +318,7 @@ uint16_t EE_Init(void)
         }
         /* Mark Page0 as valid */
         flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, PAGE0_BASE_ADDRESS, VALID_PAGE);
+        flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, PAGE0_BASE_ADDRESS+2, PAGE_VERSION);
         /* If program operation was failed, a Flash error code is returned */
         if (flashstatus != HAL_OK)
         {
@@ -343,6 +363,8 @@ uint16_t EE_Init(void)
             return flashstatus;
           }
         }
+        // Check and maybe convert page format
+        flashstatus = EE_PageConvert(PAGE0);
       }
       else /* Page0 valid, Page1 receive */
       {
@@ -372,6 +394,7 @@ uint16_t EE_Init(void)
         }
         /* Mark Page1 as valid */
         flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, PAGE1_BASE_ADDRESS, VALID_PAGE);
+        flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, PAGE1_BASE_ADDRESS+2, PAGE_VERSION);
         /* If program operation was failed, a Flash error code is returned */
         if (flashstatus != HAL_OK)
         {
@@ -439,7 +462,7 @@ uint16_t EE_VerifyPageFullyErased(uint32_t Address)
       break;
     }
     /* Next address location */
-    Address = Address + 4;
+    Address = Address + 2;
   }
 
   /* Return readstatus value: (0: Page not erased, 1: Page erased) */
@@ -475,19 +498,20 @@ uint16_t EE_ReadVariable(uint16_t VirtAddress, uint16_t* Data)
   PageStartAddress = (uint32_t)(EEPROM_START_ADDRESS + (uint32_t)(validpage * PAGE_SIZE));
 
   /* Get the valid Page end Address */
-  address = (uint32_t)((EEPROM_START_ADDRESS - 2) + (uint32_t)((1 + validpage) * PAGE_SIZE));
-
+  address = PageStartAddress + PAGE_SIZE - 2;
+  PageStartAddress += 2;    // Also don't look at the page verison number we stored here.
   /* Check each active page address starting from end */
-  while (address > (PageStartAddress + 2))
+  while (address > PageStartAddress)
   {
     /* Get the current location content to be compared with virtual address */
     addressvalue = (*(__IO uint16_t*)address);
 
     /* Compare the read address with the virtual address */
-    if (addressvalue == VirtAddress)
+    /* With this 2 byte format Low byte is address, high byte is value */
+    if ((addressvalue & 0xff) == VirtAddress)
     {
       /* Get content of Address-2 which is variable value */
-      *Data = (*(__IO uint16_t*)(address - 2));
+      *Data = (addressvalue >> 8) & 0xff;
 
       /* In case variable value is read, reset readstatus flag */
       readstatus = 0;
@@ -497,7 +521,7 @@ uint16_t EE_ReadVariable(uint16_t VirtAddress, uint16_t* Data)
     else
     {
       /* Next address location */
-      address = address - 4;
+      address = address - 2;
     }
   }
 
@@ -688,13 +712,15 @@ static uint16_t EE_VerifyPageFullWriteVariable(uint16_t VirtAddress, uint16_t Da
   address = (uint32_t)(EEPROM_START_ADDRESS + (uint32_t)(validpage * PAGE_SIZE));
 
   /* Get the valid Page end address */
-  pageendaddress = (uint32_t)((EEPROM_START_ADDRESS - 1) + (uint32_t)((validpage + 1) * PAGE_SIZE));
+  pageendaddress = address + PAGE_SIZE;
+  address += 4; // don't try using the Page type and Page version fields
 
   /* Check each active page address starting from begining */
   while (address < pageendaddress)
   {
-    /* Verify if address and address+2 contents are 0xFFFFFFFF */
-    if ((*(__IO uint32_t*)address) == 0xFFFFFFFF)
+    /* Verify if address contents are 0xFFFF */
+    addressvalue = (*(__IO uint16_t*)address);
+    if (addressvalue == 0xFFFF)
     {
       /* Found an empty slot, see if our index is in the list and the last */
       /* Instance has the value we are trying to store, we can bypass this. */
@@ -702,31 +728,22 @@ static uint16_t EE_VerifyPageFullWriteVariable(uint16_t VirtAddress, uint16_t Da
       {
         return HAL_OK;  // Value is already set to our value
       }
-      /* Set variable data */
-      flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, address, Data);
-      /* If program operation was failed, a Flash error code is returned */
-      if (flashstatus != HAL_OK)
-      {
-        return flashstatus;
-      }
-      /* Set variable virtual address */
-      flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, address + 2, VirtAddress);
+      /* Set variable and address */
+      flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, address, (Data << 8) + VirtAddress);;
       /* Return program operation status */
       return flashstatus;
     }
     else
     {
-      addressvalue = (*(__IO uint16_t*)(address+2));
-
       /* Compare the read address with the virtual address */
-      if (addressvalue == VirtAddress)
+      if ((addressvalue & 0xff) == VirtAddress)
       {
         /* Get content of Address-2 which is variable value */
-        cur_Data = (*(__IO uint16_t*)(address));
+        cur_Data = (addressvalue >> 8) & 0xff;
 
       }
       /* Next address location */
-      address = address + 4;
+      address = address + 2;
     }
   }
 
@@ -831,6 +848,81 @@ static uint16_t EE_PageTransfer(uint16_t VirtAddress, uint16_t Data)
 
   /* Set new Page status to VALID_PAGE status */
   flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, newpageaddress, VALID_PAGE);
+  flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, newpageaddress+2, PAGE_VERSION);
+
+  /* Return last operation flash status */
+  return flashstatus;
+}
+
+
+/**
+  * @brief  Convert page from 4 bytes per entry to 2...
+  * @param  validPage: 16 bit virtual address of the variable
+  * @retval Success or error status:
+  *           - FLASH_COMPLETE: on success
+  *           - PAGE_FULL: if valid page is full
+  *           - NO_VALID_PAGE: if no valid page was found
+  *           - Flash error code: on write Flash error
+  */
+static uint16_t EE_PageConvert(uint16_t validpage)
+{
+  HAL_StatusTypeDef flashstatus = HAL_OK;
+  uint32_t newpageaddress = EEPROM_START_ADDRESS;
+  uint32_t oldpageaddress;
+  uint32_t oldpageaddress_end;
+  uint32_t oldpageid = 0;
+  uint16_t varidx = 0;
+  uint16_t eepromstatus = 0, readstatus = 0;
+  uint32_t page_error = 0;
+  FLASH_EraseInitTypeDef s_eraseinit;
+
+  // vcp_printf("EE_PageConvert: %\n", validpage);
+  s_eraseinit.TypeErase   = FLASH_TYPEERASE_PAGES;
+  s_eraseinit.NbPages     = 1;
+
+  if (validpage == PAGE1)       /* Page1 valid */
+  {
+    /* New page address where variable will be moved to */
+    newpageaddress = PAGE0_BASE_ADDRESS;
+    oldpageaddress = PAGE1_BASE_ADDRESS;
+    s_eraseinit.PageAddress = PAGE0_ID;
+
+    /* Old page ID where variable will be taken from */
+    oldpageid = PAGE1_ID;
+  }
+  else if (validpage == PAGE0)  /* Page0 valid */
+  {
+    /* New page address  where variable will be moved to */
+    newpageaddress = PAGE1_BASE_ADDRESS;
+    oldpageaddress = PAGE0_BASE_ADDRESS;
+
+    s_eraseinit.PageAddress = PAGE1_ID;
+    /* Old page ID where variable will be taken from */
+    oldpageid = PAGE0_ID;
+  }
+
+  // Lets see if we need to co a conversion.
+  if (((*(__IO uint16_t*)oldpageaddress) == VALID_PAGE) && ((*(__IO uint16_t*)(oldpageaddress+2)) == PAGE_VERSION))
+  {
+    // vcp_printf("Page is valid and new version\n");
+    return HAL_OK;
+
+  }
+
+  // Make sure the new page is erased. 
+  if(!EE_VerifyPageFullyErased(newpageaddress))
+  {
+    // vcp_printf(" Need to erase new page\n");
+    flashstatus = HAL_FLASHEx_Erase(&s_eraseinit, &page_error);
+    /* If erase operation was failed, a Flash error code is returned */
+    if (flashstatus != HAL_OK)
+    {
+      return flashstatus;
+    }
+  }
+
+  /* Set the new Page status to RECEIVE_DATA status */
+  flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, newpageaddress, RECEIVE_DATA);
   /* If program operation was failed, a Flash error code is returned */
   if (flashstatus != HAL_OK)
   {
@@ -838,10 +930,54 @@ static uint16_t EE_PageTransfer(uint16_t VirtAddress, uint16_t Data)
   }
 
 
+  /* Transfer process: transfer variables from old to the new active page */
+  /* First find the end of the old data */
+  oldpageaddress_end = oldpageaddress + PAGE_SIZE - 4;
+  while ( (*(__IO uint32_t*)oldpageaddress_end) == 0xFFFFFFFF)
+  {
+    oldpageaddress_end -= 4;
+  }
+
+  // vcp_printf("Old Page start:%x end:%x\n", (uint32_t)oldpageaddress, (uint32_t)oldpageaddress_end);
+
+  for (varidx = 0; varidx < NB_OF_VAR; varidx++)
+  {
+    /* See if we find that data in the old data */
+    for (uint32_t address = oldpageaddress_end; address > oldpageaddress; address -= 4)
+    {
+      if ((*(__IO uint16_t*)(address+2)) == varidx)
+      {
+        DataVar = (*(__IO uint16_t*)address) & 0xff;
+        // vcp_printf("transfer %x:%x\n", varidx, DataVar);
+        eepromstatus = EE_VerifyPageFullWriteVariable(VIRTADDVARTAB(varidx), DataVar);
+        /* If program operation was failed, a Flash error code is returned */
+        if (eepromstatus != HAL_OK)
+        {
+          // vcp_printf("Write failed(%x) %x:%x\n", eepromstatus, varidx, DataVar);
+          return eepromstatus;
+        }
+        break;
+      }
+    }
+  }
+
+  s_eraseinit.TypeErase   = FLASH_TYPEERASE_PAGES;
+  s_eraseinit.PageAddress = oldpageid;
+  s_eraseinit.NbPages     = 1;
+  // vcp_printf("Erase old page %d\n", oldpageid);
+  /* Erase the old Page: Set old Page status to ERASED status */
+  flashstatus = HAL_FLASHEx_Erase(&s_eraseinit, &page_error);
+  /* If erase operation was failed, a Flash error code is returned */
+  if (flashstatus != HAL_OK)
+  {
+    return flashstatus;
+  }
+
+  /* Set new Page status to VALID_PAGE status */
+  // vcp_printf("Set newpage to valid\n");
+  flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, newpageaddress, VALID_PAGE);
+  flashstatus = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, newpageaddress+2, PAGE_VERSION);
 
   /* Return last operation flash status */
   return flashstatus;
 }
-
-
-


### PR DESCRIPTION
@OpusK,

Here is an update to #61 - The two byte version.  I synced up my develop branch to after your merge of the 4 byte code and then copied in the two byte version of changes. 

Here are the later changes made to convert the 4 byte entries into 2 byte entries.

This change also included an optional change I made, which deferred the actual initialization of  the EEPROM until someone actually needed it.  That is until some one calls something like EEPROM.read or EEPROM.write, or  the size function.

Two reasons:   Why take the time to init if if the actual program never uses it.
And more for my point, if you init the cod eas early as drv_eeprom_init is called, you can not use things like vcp_printf(...) to debug stuff...  There are a few of these scattered in the code that are commented out now.

Update lib_f103.a